### PR TITLE
Revert "Add toggle for using the bin width as the x error for errorbar histograms"

### DIFF
--- a/yahist/hist1d.py
+++ b/yahist/hist1d.py
@@ -1128,7 +1128,6 @@ class Hist1D(object):
         legend=True,
         counts=False,
         errors=False,
-        errors_binwidth=True,
         fmt="o",
         label=None,
         color=None,
@@ -1158,8 +1157,6 @@ class Hist1D(object):
             Font size of count labels
         errors, bool False
             If True, plot markers with error bars (`ax.errorbar()`) instead of `ax.hist()`.
-        errors_binwidth, bool True
-            If True, the bin width is plotted as the x error if `errors=True`.
         fmt : str, default "o"
             `fmt` kwarg used for matplotlib plotting
         label : str, default None
@@ -1202,11 +1199,6 @@ class Hist1D(object):
         mask = ((counts != 0.0) | (yerrs != 0.0)) & np.isfinite(counts)
         centers = self.bin_centers
 
-        if errors_binwidth:
-            xerr = xerrs[mask]
-        else:
-            xerr = None
-
         if show_errors:
             yerr = yerrs[mask]
             if self.errors_up is not None:
@@ -1214,7 +1206,7 @@ class Hist1D(object):
             patches = ax.errorbar(
                 centers[mask],
                 counts[mask],
-                xerr=xerr,
+                xerr=xerrs[mask],
                 yerr=yerr,
                 fmt=fmt,
                 color=color,


### PR DESCRIPTION
Reverts aminnj/yahist#13

I merged the PR too eagerly since it looked like CI succeeded, but evidently it failed.

Failing unit test:
https://github.com/aminnj/yahist/actions/runs/9135238833/job/25122258972

@jkguiang  if you have a chance to look into it, that'd be great. I can also take a look this weekend